### PR TITLE
bug fix in crosstab_bayes_factor

### DIFF
--- a/auditai/utils/crosstabs.py
+++ b/auditai/utils/crosstabs.py
@@ -144,6 +144,9 @@ def crosstab_bayes_factor(ctab, prior=None):
         0.26162148804907587
 
     """
+    if isinstance(ctab, pd.DataFrame):
+        ctab = ctab.values
+
     if prior is None:
         prior = np.ones(shape=ctab.shape)
 


### PR DESCRIPTION
crosstab_bayes_factor expects ndarray, when called from bias_test_check receives a data frame