### PR TITLE
reindex ct_table to ensure it has expected columns and rows

### DIFF
--- a/auditai/simulations.py
+++ b/auditai/simulations.py
@@ -295,6 +295,12 @@ def generate_bayesfactors(clf, df, feature_names, categories,
                 ct_table = pd.crosstab(
                     sorted_df.loc[mask, category],
                     sorted_df.loc[mask, matched_col]
+                )
+
+                ct_table = ct_table.reindex(
+                    index=[v1, v2],
+                    columns=[0, 1],
+                    fill_value=0
                 ).values
 
                 feat_sim = sim_beta_ratio(ct_table, thresh, prior_strength,


### PR DESCRIPTION
- Current `generate_bayesfactors` will fail if all users pass or fail, as the ct_table generated will not be of the expected size (2x2)
- Reindex to make sure that the ct_table is 2x2, fill with 0 when an index, match value pair doesn't exist 